### PR TITLE
Enabled support to check instance availability

### DIFF
--- a/cloudamqp/helpers.go
+++ b/cloudamqp/helpers.go
@@ -36,9 +36,3 @@ func checkInstanceUntilAvailable(instance *Instance, timeoutInSeconds float64) e
 		}
 	}
 }
-
-// checkInstanceUntilDeleted Blocks execution until the instance
-// is fully terminated
-// func checkInstanceUntilDeleted(instance *Instance) error {
-// 	return nil
-// }

--- a/cloudamqp/helpers.go
+++ b/cloudamqp/helpers.go
@@ -1,0 +1,44 @@
+package cloudamqp
+
+import (
+	"errors"
+	"net"
+	"net/url"
+	"time"
+)
+
+// checkInstanceUntilAvailable Blocks execution until the instance
+// is fully operational
+func checkInstanceUntilAvailable(instance *Instance, timeoutInSeconds float64) error {
+	instanceURL, _ := url.Parse(instance.URL)
+	initialTime := time.Now()
+
+	var network string
+
+	if instanceURL.Scheme != "amqp" {
+		network = "tcp"
+	}
+
+	for {
+		conn, err := net.DialTimeout(
+			network,
+			instanceURL.Host,
+			time.Second,
+		)
+
+		if time.Now().Sub(initialTime).Seconds() > timeoutInSeconds {
+			return errors.New("Max timeout reached")
+		}
+
+		if err == nil {
+			conn.Close()
+			return nil
+		}
+	}
+}
+
+// checkInstanceUntilDeleted Blocks execution until the instance
+// is fully terminated
+// func checkInstanceUntilDeleted(instance *Instance) error {
+// 	return nil
+// }

--- a/cloudamqp/helpers_test.go
+++ b/cloudamqp/helpers_test.go
@@ -1,0 +1,101 @@
+package cloudamqp
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func rabbitMQTestServer() net.Listener {
+	startPort := 5672
+
+	var listener net.Listener
+	var errListener error
+
+	for {
+		listener, errListener = net.Listen(
+			"tcp",
+			fmt.Sprintf("127.0.0.1:%d", startPort),
+		)
+
+		if errListener != nil {
+			startPort++
+			continue
+		}
+
+		return listener
+	}
+}
+
+func checkUnusedPort() int {
+	port := 10000
+
+	for {
+		conn, err := net.DialTimeout(
+			"tcp",
+			fmt.Sprintf("127.0.0.1:%d", port),
+			time.Millisecond*10,
+		)
+
+		if err == nil {
+			conn.Close()
+			port++
+			continue
+		}
+
+		return port
+	}
+}
+
+func TestCheckInstanceUntilAvailableFailture(t *testing.T) {
+	unusedPort := checkUnusedPort()
+
+	instance := Instance{
+		URL: fmt.Sprintf(
+			"tcp://127.0.0.1:%d",
+			unusedPort,
+		),
+	}
+
+	resultErr := checkInstanceUntilAvailable(
+		&instance,
+		float64(1),
+	)
+
+	assert.Error(t, resultErr)
+}
+
+func TestCheckInstanceUntilAvailableSuccess(t *testing.T) {
+	listener := rabbitMQTestServer()
+
+	go func() {
+		for {
+			conn, errAccept := listener.Accept()
+
+			if errAccept != nil {
+				log.Panicln(errAccept)
+			}
+
+			conn.Write([]byte("OK"))
+		}
+	}()
+
+	instance := Instance{
+		URL: fmt.Sprintf(
+			"%s://%s",
+			listener.Addr().Network(),
+			listener.Addr().String(),
+		),
+	}
+
+	resultErr := checkInstanceUntilAvailable(
+		&instance,
+		float64(1),
+	)
+
+	assert.NoError(t, resultErr)
+}

--- a/cloudamqp/instances.go
+++ b/cloudamqp/instances.go
@@ -67,7 +67,7 @@ func (s *InstanceService) Create(params *CreateInstanceParams) (*Instance, *http
 	return instance, resp, relevantError(err, *apiError)
 }
 
-// CreateAndWait Create a new CloudAMP instance and wats for it to be available
+// CreateAndWait Create a new CloudAMP instance and waits for it to be available
 // https://customer.cloudamqp.com/team/api
 func (s *InstanceService) CreateAndWait(params *CreateInstanceParams, timeoutInSeconds float64) (*Instance, *http.Response, error) {
 	instance, resp, err := s.Create(params)

--- a/cloudamqp/instances.go
+++ b/cloudamqp/instances.go
@@ -67,6 +67,18 @@ func (s *InstanceService) Create(params *CreateInstanceParams) (*Instance, *http
 	return instance, resp, relevantError(err, *apiError)
 }
 
+// CreateAndWait Create a new CloudAMP instance and wats for it to be available
+// https://customer.cloudamqp.com/team/api
+func (s *InstanceService) CreateAndWait(params *CreateInstanceParams, timeoutInSeconds float64) (*Instance, *http.Response, error) {
+	instance, resp, err := s.Create(params)
+
+	if err == nil {
+		checkInstanceUntilAvailable(instance, timeoutInSeconds)
+	}
+
+	return instance, resp, err
+}
+
 // UpdateInstanceParams are the parameters for OrganizationService.Create.
 type UpdateInstanceParams struct {
 	Name  string `url:"name,omitempty"`


### PR DESCRIPTION
Added method and helper functions to check availability of the created instance.

Related to https://github.com/waveaccounting/terraform-provider-cloudamqp/issues/13